### PR TITLE
fix: In CONTRIBUTING, link directly to the Question template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ The development language is **English**. All comments and documentation should b
 
 ### Have a question?
 
-* Ask the community on [Discord](https://crpt.fyi/berty-discord)
+You can ask a question by [opening a new issue](https://github.com/berty/berty/issues/new/choose) and choosing `Question`. Don't forget to check if this question has been asked before ([current `question` labeled issues](https://github.com/berty/berty/issues?q=is%3Aissue+is%3Aopen+label%3Aquestion))
 
 ## Ways to contribute
 


### PR DESCRIPTION
Change the "Have a question" section to link to the new Question form on Berty issues. This replaces the link to ask questions on Discord. Is that correct? Or should will also include the link to ask on Discord?

Signed-off-by: jefft0 <jeff@thefirst.org>